### PR TITLE
SNSLogClient now checks level string before doing ELogPriority.forValue

### DIFF
--- a/product-sns/src/main/java/org/phoebus/sns/logbook/SNSLogClient.java
+++ b/product-sns/src/main/java/org/phoebus/sns/logbook/SNSLogClient.java
@@ -276,7 +276,10 @@ public class SNSLogClient implements LogClient
             Iterator<Attachment> attachIter = attachments.iterator();
             
             // Create the entry
-            long id = elog.createEntry(logIter.hasNext() ? logIter.next().getName() : "", log.getTitle(), log.getDescription(), ELogPriority.forName(log.getLevel()));
+            String level = log.getLevel();
+            
+            ELogPriority priority = (level.isEmpty()) ? ELogPriority.Normal : ELogPriority.forName(level);
+            long id = elog.createEntry(logIter.hasNext() ? logIter.next().getName() : "", log.getTitle(), log.getDescription(), priority);
             
             // Add all attached files to the entry
             while (attachIter.hasNext())
@@ -309,6 +312,8 @@ public class SNSLogClient implements LogClient
                 Tag t = tagIter.next();
                 elog.addCategory(id, t.getName());
             }
+            
+            return log;
         } 
         catch (Exception e)
         {

--- a/product-sns/src/main/java/org/phoebus/sns/logbook/SNSLogFactory.java
+++ b/product-sns/src/main/java/org/phoebus/sns/logbook/SNSLogFactory.java
@@ -12,7 +12,7 @@ public class SNSLogFactory implements LogFactory
     private static final String read_only_username = prefs.get("read_only_username");
     private static final String read_only_password = prefs.get("read_only_password");
     
-    private static final String ID = "org.phoebus.sns.logbook";
+    private static final String ID = "SNS";
     
     @Override
     public String getId()


### PR DESCRIPTION
The priority level string is not a required field in the log entry view and so an entry can be submitted without this being set. If ELogPriority.forValue receives an empty string it will throw an exception. We now check the string. If it is empty, set priority to normal as default, otherwise set to requested level.