### PR TITLE
Elog fixes

### DIFF
--- a/product-sns/src/main/java/org/phoebus/sns/logbook/SNSAttachment.java
+++ b/product-sns/src/main/java/org/phoebus/sns/logbook/SNSAttachment.java
@@ -81,4 +81,10 @@ public class SNSAttachment implements Attachment
         return file;
     }
 
+    @Override
+    public String getName()
+    {
+        return file.getName();
+    }
+
 }

--- a/product-sns/src/main/java/org/phoebus/sns/logbook/elog/ELog.java
+++ b/product-sns/src/main/java/org/phoebus/sns/logbook/elog/ELog.java
@@ -293,6 +293,7 @@ public class ELog implements Closeable
             statement.setTimestamp(1, new java.sql.Timestamp(start.getTime()));
             statement.setTimestamp(2, new java.sql.Timestamp(end.getTime()));
             final ResultSet result = statement.executeQuery();
+            rdb.releaseConnection(connection);
             while (result.next())
             {
                 final long entry_id = result.getLong(1);
@@ -302,15 +303,19 @@ public class ELog implements Closeable
                 final String title = result.getString(6);
                 final String text = result.getString(7);
                 final List<String> logbooks = getLogbooks(entry_id);
+                System.out.println("Got logbooks");
                 final List<ELogCategory> categories = getCategories(entry_id);
+                System.out.println("Got categories");                
                 final List<ELogAttachment> images = getImageAttachments(entry_id);
+                System.out.println("Got images");
                 final List<ELogAttachment> attachments = getOtherAttachments(entry_id);
+                System.out.println("Got attachments");
                 entries.add(new ELogEntry(entry_id, prio, user, date, title, text, logbooks, categories, images, attachments));
             }
         }
         finally
         {
-            rdb.releaseConnection(connection);
+            rdb.clear();
         }
 
         return entries;

--- a/product-sns/src/main/java/org/phoebus/sns/logbook/elog/ELog.java
+++ b/product-sns/src/main/java/org/phoebus/sns/logbook/elog/ELog.java
@@ -303,19 +303,11 @@ public class ELog implements Closeable
                 final String title = result.getString(6);
                 final String text = result.getString(7);
                 final List<String> logbooks = getLogbooks(entry_id);
-                System.out.println("Got logbooks");
                 final List<ELogCategory> categories = getCategories(entry_id);
-                System.out.println("Got categories");                
                 final List<ELogAttachment> images = getImageAttachments(entry_id);
-                System.out.println("Got images");
                 final List<ELogAttachment> attachments = getOtherAttachments(entry_id);
-                System.out.println("Got attachments");
                 entries.add(new ELogEntry(entry_id, prio, user, date, title, text, logbooks, categories, images, attachments));
             }
-        }
-        finally
-        {
-            rdb.clear();
         }
 
         return entries;

--- a/product-sns/src/test/java/org/phoebus/sns/logbook/DemoSNSLogClient.java
+++ b/product-sns/src/test/java/org/phoebus/sns/logbook/DemoSNSLogClient.java
@@ -32,7 +32,7 @@ import javafx.util.Pair;
 public class DemoSNSLogClient extends Application
 {
     private final static LogService logService = LogService.getInstance();
-    private final static LogFactory logFactory = logService.getLogFactories().get("org.phoebus.sns.logbook");
+    private final static LogFactory logFactory = logService.getLogFactories().get("SNS");
     private static LogClient logClient;
     
     private VBox     vbox;


### PR DESCRIPTION
Reducing the number of logs pulled for list logs and find logs by search to 24 hours. This should reduce the time it takes and the chances of sessions per user being exceeded.

Updated SNSAttachment to match org.phoebus.logbook.Attachment API.

Implemented org.phoebus.logbook.LogClient.findLogsBySearch in SNSLogClient