### PR TITLE
settings: use https to access accelerator server 

### DIFF
--- a/product-sns/settings.ini
+++ b/product-sns/settings.ini
@@ -20,7 +20,7 @@ org.phoebus.ui/ui_monitor_period=5000
 org.phoebus.pv.ca/addr_list=127.0.0.1 webopi.sns.gov:5066 160.91.228.17
 
 # Display Builder
-org.phoebus.ui/top_resources=http://ics-srv-web2.sns.ornl.gov/ade/css/Share/SNS_CCR_Screens/Site/main.opi, Accelerator | https://webopi.sns.gov/webopi/opi/Instruments.opi, Instruments | examples:/01_main.bob?app=display_runtime,Example Display | pv://?sim://sine&app=probe,Probe Example | pv://?sim://sine&loc://x(10)&app=pv_table,PV Table Example
+org.phoebus.ui/top_resources=https://ics-srv-web2.sns.ornl.gov/ade/css/Share/SNS_CCR_Screens/Site/main.opi, Accelerator | https://webopi.sns.gov/webopi/opi/Instruments.opi, Instruments | examples:/01_main.bob?app=display_runtime,Example Display | pv://?sim://sine&app=probe,Probe Example | pv://?sim://sine&loc://x(10)&app=pv_table,PV Table Example
 
 org.csstudio.display.builder.runtime/python_path=
 


### PR DESCRIPTION
. . . for display builder files

http is being deprecated